### PR TITLE
avoid compile error on glibc>=2.20 environment

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -83,7 +83,7 @@ memdup(const void *s, size_t n) {
 	return (dst = malloc(n)) ? memcpy(dst, s, n) : NULL;
 }
 
-#ifndef __USE_GNU
+#if !defined(__USE_XOPEN2K8) && !defined(__USE_GNU)
 char *
 strndup(const char *s1, size_t n) {
 	char *dst;

--- a/src/tcpeek.h
+++ b/src/tcpeek.h
@@ -259,7 +259,7 @@ extern int
 strisdigit(const char *str);
 extern struct lnklist *
 strsplit(const char *str, const char *sep, size_t num);
-#ifndef __USE_GNU
+#if !defined(__USE_XOPEN2K8) && !defined(__USE_GNU)
 extern char *
 strndup(const char *s1, size_t n);
 #endif


### PR DESCRIPTION
libc-2.20以上の環境（例えば2016.07.26時点でのArch Linux）でコンパイルエラーになるのを回避する。

エラーは以下
```
$ make
make  all-recursive
make[1]: Entering directory '/home/ubuntu/work/tcpeek'
Making all in src
make[2]: Entering directory '/home/ubuntu/work/tcpeek/src'
gcc -DHAVE_CONFIG_H -I. -I..     -pthread -g -O2 -W -Wall -Wno-unused-parameter -MT tcpeek-tcpeek.o -MD -MP -MF .deps/tcpeek-tcpeek.Tpo -c -o tcpeek-tcpeek.o `test -f 'tcpeek.c' || echo './'`tcpeek.c
In file included from /usr/include/string.h:630:0,
                 from tcpeek.h:9,
                 from tcpeek.c:1:
tcpeek.h:264:1: error: expected identifier or ‘(’ before ‘__extension__’
 strndup(const char *s1, size_t n);
 ^
Makefile:463: recipe for target 'tcpeek-tcpeek.o' failed
make[2]: *** [tcpeek-tcpeek.o] Error 1
make[2]: Leaving directory '/home/ubuntu/work/tcpeek/src'
Makefile:372: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/ubuntu/work/tcpeek'
Makefile:313: recipe for target 'all' failed
make: *** [all] Error 2
```

以下の環境でビルド成功＆動作することは確認しました。
* Debian 5 (libc-2.7)
* Debian 6 (libc-2.13)
* Debian 8 (libc-2.19)
* Ubuntu15.10 (libc-2.21)
* Arch 2016.07.26 (libc-2.23)
* MacOSX 10.11.6
